### PR TITLE
Reduce duplication with parent class abstractions

### DIFF
--- a/lib/image_downloader.rb
+++ b/lib/image_downloader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Class to handle downloading images from a list of URLs.
 class ImageDownloader
   def initialize(urls:, storage:, logger:, progname:)

--- a/spec/spider_helper.rb
+++ b/spec/spider_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "tanakai_helper"
 
 RSpec.shared_examples "a store spider" do

--- a/spec/tanakai_helper.rb
+++ b/spec/tanakai_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require "tanakai"
 require_relative "../config/boot"

--- a/spiders/aldea_juegos_spider.rb
+++ b/spiders/aldea_juegos_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Aldea Juegos store spider
-# engine: prestashop
-class AldeaJuegosSpider < ApplicationSpider
+class AldeaJuegosSpider < EcommerceEngines::PrestaShop::Spider
   @name = "aldea_juegos_spider"
   @store = {
     name: "Aldea Juegos",
@@ -11,67 +10,10 @@ class AldeaJuegosSpider < ApplicationSpider
   @start_urls = ["https://www.aldeajuegos.cl/7-juegos-de-mesa?q=Disponibilidad-En+stock"]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("div#js-product-list article")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page_node = response.at_css("nav.pagination li a[@rel=next]")
-    return unless next_page_node
-
-    absolute_url(next_page_node[:href], base: url)
-  end
-
   private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node)
-    node.at_css(".product-title a")[:href]
-  end
 
   def get_title(node)
     url = node.at_css("img")[:src]
     File.basename(url, ".jpg").gsub("-", " ")
-  end
-
-  def get_price(node)
-    price_node = node.css("span.price").last
-    scan_int(price_node.text)
-  end
-
-  def in_stock?(node)
-    node.at_css("li.out_of_stock").nil?
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
-  end
-
-  def get_image_url(node)
-    node.at_css("img")["data-full-size-image-url"]
-  rescue NoMethodError
-    nil
   end
 end

--- a/spiders/application_spider.rb
+++ b/spiders/application_spider.rb
@@ -99,4 +99,8 @@ class ApplicationSpider < Tanakai::Base
     next_page_url = next_page_url(response, url)
     request_to(:parse, url: next_page_url) if next_page_url
   end
+
+  def purchasable?(node)
+    in_stock?(node)
+  end
 end

--- a/spiders/application_spider.rb
+++ b/spiders/application_spider.rb
@@ -92,4 +92,11 @@ class ApplicationSpider < Tanakai::Base
 
     paginate(response, url)
   end
+
+  private
+
+  def paginate(response, url)
+    next_page_url = next_page_url(response, url)
+    request_to(:parse, url: next_page_url) if next_page_url
+  end
 end

--- a/spiders/application_spider.rb
+++ b/spiders/application_spider.rb
@@ -127,6 +127,16 @@ class ApplicationSpider < Tanakai::Base
     absolute_url(next_page_node[:href], base: url)
   end
 
+  def parse_product_node(node, url:)
+    {
+      url: get_url(node, url),
+      title: get_title(node),
+      price: get_price(node),
+      stock: purchasable?(node),
+      image_url: get_image_url(node, url)
+    }
+  end
+
   private
 
   def paginate(response, url)
@@ -134,7 +144,7 @@ class ApplicationSpider < Tanakai::Base
     request_to(:parse, url: next_page_url) if next_page_url
   end
 
-  def get_url(node, url)
+  def get_url(node, url = nil)
     selector = get_selector(:url)
     rel_url = node.at_css(selector)["href"]
     absolute_url(rel_url, base: url)

--- a/spiders/application_spider.rb
+++ b/spiders/application_spider.rb
@@ -85,4 +85,11 @@ class ApplicationSpider < Tanakai::Base
   class << self
     attr_reader :store
   end
+
+  def parse(response, url:, data: {})
+    items = parse_index(response, url:)
+    items.each { |item| send_item item }
+
+    paginate(response, url)
+  end
 end

--- a/spiders/application_spider.rb
+++ b/spiders/application_spider.rb
@@ -92,6 +92,14 @@ class ApplicationSpider < Tanakai::Base
     def selector(key, selector)
       selectors[key] = selector
     end
+
+    def inherited(subclass)
+      super
+      subclass.instance_variable_set(
+        :@selectors,
+        selectors.dup
+      )
+    end
   end
 
   def get_selector(key)

--- a/spiders/cartonazo_spider.rb
+++ b/spiders/cartonazo_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Cartonazo store spider
-# Engine: woocommerce
-class CartonazoSpider < ApplicationSpider
+class CartonazoSpider < EcommerceEngines::WooCommerce::Spider
   @name = "cartonazo_spider"
   @store = {
     name: "Cartonazo",
@@ -10,67 +9,4 @@ class CartonazoSpider < ApplicationSpider
   }
   @start_urls = ["https://cartonazo.com/categoria-producto/juego-de-mesa"]
   @config = {}
-
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("ul.products li.product")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("nav.woocommerce-pagination li a.next")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
-
-  private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node)
-    node.at_css("a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css("h2").text
-  end
-
-  def get_price(node)
-    price_node = node.css("span.price bdi").last
-    scan_int(price_node.text) if price_node
-  end
-
-  def in_stock?(node)
-    node.classes.include?("instock")
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
-  end
-
-  def get_image_url(node)
-    node.at_css("img")["srcset"].split(",").last.split.first
-  rescue NoMethodError
-    nil
-  end
 end

--- a/spiders/cartonazo_spider.rb
+++ b/spiders/cartonazo_spider.rb
@@ -9,4 +9,6 @@ class CartonazoSpider < EcommerceEngines::WooCommerce::Spider
   }
   @start_urls = ["https://cartonazo.com/categoria-producto/juego-de-mesa"]
   @config = {}
+
+  image_url_strategy(:srcset)
 end

--- a/spiders/dementegames_spider.rb
+++ b/spiders/dementegames_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Demente Games store spider
-# engine: Prestashop
-class DementegamesSpider < ApplicationSpider
+class DementegamesSpider < EcommerceEngines::PrestaShop::Spider
   @name = "dementegames_spider"
   @store = {
     name: "Demente Games",
@@ -10,28 +9,6 @@ class DementegamesSpider < ApplicationSpider
   }
   @start_urls = ["https://dementegames.cl/10-juegos-de-mesa?q=Existencias-En+stock"]
   @config = {}
-
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("div#js-product-list article")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
 
   def next_page_url(response, url)
     # This store doesn't disable the next page link on the last pagination result
@@ -43,34 +20,7 @@ class DementegamesSpider < ApplicationSpider
 
   private
 
-  def paginate(response, url)
-    next_url = next_page_url(response, url)
-    request_to(:parse, url: next_url) if next_url
-  end
-
-  def get_url(node)
-    node.at_css(".product-title a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css(".product-title").text.strip
-  end
-
-  def get_price(node)
-    node.at_css("span.price")[:content].to_i
-  end
-
   def in_stock?(node)
     node.at_css("form button")["disabled"].nil?
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
-  end
-
-  def get_image_url(node)
-    node.at_css("img")["data-full-size-image-url"]
-  rescue NoMethodError
-    nil
   end
 end

--- a/spiders/dementegames_spider.rb
+++ b/spiders/dementegames_spider.rb
@@ -10,17 +10,13 @@ class DementegamesSpider < EcommerceEngines::PrestaShop::Spider
   @start_urls = ["https://dementegames.cl/10-juegos-de-mesa?q=Existencias-En+stock"]
   @config = {}
 
+  selector :stock, "form button[disabled]"
+
   def next_page_url(response, url)
     # This store doesn't disable the next page link on the last pagination result
     next_page = response.at_css("nav.pagination li a[rel=next]")
     return if next_page.nil? || next_page.classes.include?("disabled")
 
     absolute_url(next_page[:href], base: url)
-  end
-
-  private
-
-  def in_stock?(node)
-    node.at_css("form button")["disabled"].nil?
   end
 end

--- a/spiders/devir_spider.rb
+++ b/spiders/devir_spider.rb
@@ -14,26 +14,13 @@ class DevirSpider < ApplicationSpider
   selector :index_product, "div.products li.item"
   selector :next_page, "a[title='Siguiente']"
   selector :title, "strong a"
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
+  selector :url, "strong a"
 
   private
 
   def in_stock?(node)
     # check the presence of the add to cart form
     node.at_css("form")&.attr("data-role") == "tocart-form"
-  end
-
-  def get_url(node)
-    node.at_css("strong a")[:href]
   end
 
   def get_price(node)
@@ -45,7 +32,7 @@ class DevirSpider < ApplicationSpider
     scan_int(clean_price_text)
   end
 
-  def get_image_url(node)
+  def get_image_url(node, _url)
     node.at_css("img.product-image-photo")[:src]
   rescue NoMethodError
     nil

--- a/spiders/diverti_spider.rb
+++ b/spiders/diverti_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Diverti store spider
-# engine: Prestashop
-class DivertiSpider < ApplicationSpider
+class DivertiSpider < EcommerceEngines::PrestaShop::Spider
   @name = "diverti_spider"
   @store = {
     name: "Diverti",
@@ -10,28 +9,6 @@ class DivertiSpider < ApplicationSpider
   }
   @start_urls = ["https://www.diverti.cl/juegos-de-mesa-16?en-stock=1"]
   @config = {}
-
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("div#js-product-list article")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
 
   def next_page_url(response, url)
     # This store doesn't disable the next page link on the last pagination result
@@ -43,35 +20,7 @@ class DivertiSpider < ApplicationSpider
 
   private
 
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node)
-    node.at_css(".product-title a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css(".product-title").text.strip
-  end
-
-  def get_price(node)
-    price_node = node.at_css("span.price")
-    scan_int(price_node.text) if price_node
-  end
-
   def in_stock?(node)
     node.at_css("div.ago").text.strip.empty?
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
-  end
-
-  def get_image_url(node)
-    node.at_css("img")["data-full-size-image-url"]
-  rescue NoMethodError
-    nil
   end
 end

--- a/spiders/dr_juegos_spider.rb
+++ b/spiders/dr_juegos_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Dr. Juegos store spider
-# engine: prestashop
-class DrJuegosSpider < ApplicationSpider
+class DrJuegosSpider < EcommerceEngines::PrestaShop::Spider
   @name = "dr_juegos_spider"
   @store = {
     name: "Dr. Juegos",
@@ -11,41 +10,7 @@ class DrJuegosSpider < ApplicationSpider
   @start_urls = ["https://www.drjuegos.cl/2-todos-los-productos?q=Disponibilidad-En+stock"]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("div#js-product-list article")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("nav.pagination li a[@rel=next]")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
-
   private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
 
   def get_url(node)
     node.at_css("h5 a")[:href]
@@ -55,17 +20,8 @@ class DrJuegosSpider < ApplicationSpider
     node.at_css("h5").text.strip
   end
 
-  def get_price(node)
-    price_node = node.css("span.price").last
-    scan_int(price_node.text)
-  end
-
   def in_stock?(node)
     !node.at_css("button.add-to-cart").nil?
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
   end
 
   def get_image_url(node)

--- a/spiders/dr_juegos_spider.rb
+++ b/spiders/dr_juegos_spider.rb
@@ -10,18 +10,13 @@ class DrJuegosSpider < EcommerceEngines::PrestaShop::Spider
   @start_urls = ["https://www.drjuegos.cl/2-todos-los-productos?q=Disponibilidad-En+stock"]
   @config = {}
 
+  selector :title, "h5"
+  selector :stock, "div.product-availability span.unavailable"
+
   private
 
   def get_url(node)
     node.at_css("h5 a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css("h5").text.strip
-  end
-
-  def in_stock?(node)
-    !node.at_css("button.add-to-cart").nil?
   end
 
   def get_image_url(node)

--- a/spiders/dr_juegos_spider.rb
+++ b/spiders/dr_juegos_spider.rb
@@ -12,14 +12,11 @@ class DrJuegosSpider < EcommerceEngines::PrestaShop::Spider
 
   selector :title, "h5"
   selector :stock, "div.product-availability span.unavailable"
+  selector :url, "h5 a"
 
   private
 
-  def get_url(node)
-    node.at_css("h5 a")[:href]
-  end
-
-  def get_image_url(node)
+  def get_image_url(node, _url)
     node.at_css("img")[:src].sub("home_default", "large_default")
   rescue NoMethodError
     nil

--- a/spiders/ecommerce_engines/bsale/spider.rb
+++ b/spiders/ecommerce_engines/bsale/spider.rb
@@ -4,19 +4,9 @@ module EcommerceEngines
   module Bsale
     # Base spider class for all stores build with Bsale
     class Spider < ApplicationSpider
-      def parse_product_node(node, url:)
-        {
-          url: get_url(node, url),
-          title: get_title(node),
-          price: get_price(node),
-          stock: purchasable?(node),
-          image_url: get_image_url(node)
-        }
-      end
-
       private
 
-      def get_image_url(node)
+      def get_image_url(node, _url)
         tag = get_selector(:image_tag)
         attr = get_selector(:image_attr)
         node.at_css(tag).attr(attr).then do |url|

--- a/spiders/ecommerce_engines/bsale/spider.rb
+++ b/spiders/ecommerce_engines/bsale/spider.rb
@@ -4,13 +4,6 @@ module EcommerceEngines
   module Bsale
     # Base spider class for all stores build with Bsale
     class Spider < ApplicationSpider
-      def parse(response, url:, data: {})
-        items = parse_index(response, url:)
-        items.each { |item| send_item item }
-
-        paginate(response, url)
-      end
-
       def parse_index(response, url:, selector:, data: {})
         listings = response.css(selector)
         listings.map { |listing| parse_product_node(listing, url:) }

--- a/spiders/ecommerce_engines/bsale/spider.rb
+++ b/spiders/ecommerce_engines/bsale/spider.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module EcommerceEngines
+  module Bsale
+    # Base spider class for all stores build with Bsale
+    class Spider < ApplicationSpider
+      def parse(response, url:, data: {})
+        items = parse_index(response, url:)
+        items.each { |item| send_item item }
+
+        paginate(response, url)
+      end
+
+      def parse_index(response, url:, selector:, data: {})
+        listings = response.css(selector)
+        listings.map { |listing| parse_product_node(listing, url:) }
+      end
+
+      def parse_product_node(node, url:)
+        {
+          url: get_url(node, url),
+          title: get_title(node),
+          price: get_price(node),
+          stock: purchasable?(node),
+          image_url: get_image_url(node)
+        }
+      end
+
+      def next_page_url(response, url, selector)
+        next_page_node = response.at_css(selector)
+        return unless next_page_node
+
+        absolute_url(next_page_node[:href], base: url)
+      end
+
+      private
+
+      def paginate(response, url)
+        next_page_url = next_page_url(response, url)
+        request_to(:parse, url: next_page_url) if next_page_url
+      end
+
+      def get_url(node, url)
+        rel_url = node.at_css("a")[:href]
+        absolute_url(rel_url, base: url)
+      end
+
+      def get_price(node, selector)
+        price_node = node.at_css(selector)
+        return unless price_node
+
+        scan_int(price_node.text)
+      end
+
+      def in_stock?(node, selector)
+        node.at_css(selector).nil?
+      end
+
+      def purchasable?(node)
+        in_stock?(node)
+      end
+
+      def get_image_url(node, attribute)
+        node.at_css("img").attr(attribute).then do |url|
+          uri = URI.parse(url)
+          uri.query = nil
+          uri.to_s
+        end
+      rescue NoMethodError
+        nil
+      end
+    end
+  end
+end

--- a/spiders/ecommerce_engines/bsale/spider.rb
+++ b/spiders/ecommerce_engines/bsale/spider.rb
@@ -28,11 +28,6 @@ module EcommerceEngines
 
       private
 
-      def paginate(response, url)
-        next_page_url = next_page_url(response, url)
-        request_to(:parse, url: next_page_url) if next_page_url
-      end
-
       def get_url(node, url)
         rel_url = node.at_css("a")[:href]
         absolute_url(rel_url, base: url)

--- a/spiders/ecommerce_engines/bsale/spider.rb
+++ b/spiders/ecommerce_engines/bsale/spider.rb
@@ -44,10 +44,6 @@ module EcommerceEngines
         node.at_css(selector).nil?
       end
 
-      def purchasable?(node)
-        in_stock?(node)
-      end
-
       def get_image_url(node, attribute)
         node.at_css("img").attr(attribute).then do |url|
           uri = URI.parse(url)

--- a/spiders/ecommerce_engines/bsale/spider.rb
+++ b/spiders/ecommerce_engines/bsale/spider.rb
@@ -4,11 +4,6 @@ module EcommerceEngines
   module Bsale
     # Base spider class for all stores build with Bsale
     class Spider < ApplicationSpider
-      def parse_index(response, url:, selector:, data: {})
-        listings = response.css(selector)
-        listings.map { |listing| parse_product_node(listing, url:) }
-      end
-
       def parse_product_node(node, url:)
         {
           url: get_url(node, url),
@@ -19,33 +14,12 @@ module EcommerceEngines
         }
       end
 
-      def next_page_url(response, url, selector)
-        next_page_node = response.at_css(selector)
-        return unless next_page_node
-
-        absolute_url(next_page_node[:href], base: url)
-      end
-
       private
 
-      def get_url(node, url)
-        rel_url = node.at_css("a")[:href]
-        absolute_url(rel_url, base: url)
-      end
-
-      def get_price(node, selector)
-        price_node = node.at_css(selector)
-        return unless price_node
-
-        scan_int(price_node.text)
-      end
-
-      def in_stock?(node, selector)
-        node.at_css(selector).nil?
-      end
-
-      def get_image_url(node, attribute)
-        node.at_css("img").attr(attribute).then do |url|
+      def get_image_url(node)
+        tag = get_selector(:image_tag)
+        attr = get_selector(:image_attr)
+        node.at_css(tag).attr(attr).then do |url|
           uri = URI.parse(url)
           uri.query = nil
           uri.to_s

--- a/spiders/ecommerce_engines/jumpseller/spider.rb
+++ b/spiders/ecommerce_engines/jumpseller/spider.rb
@@ -4,13 +4,6 @@ module EcommerceEngines
   module Jumpseller
     # Base spider class for all stores build with Jumpseller
     class Spider < ApplicationSpider
-      def parse(response, url:, data: {})
-        items = parse_index(response, url:)
-        items.each { |item| send_item item }
-
-        paginate(response, url)
-      end
-
       def parse_product_node(node, url:)
         {
           url: get_url(node, url),

--- a/spiders/ecommerce_engines/jumpseller/spider.rb
+++ b/spiders/ecommerce_engines/jumpseller/spider.rb
@@ -16,7 +16,8 @@ module EcommerceEngines
 
       private
 
-      def get_image_url(node, split_string)
+      def get_image_url(node)
+        split_string = get_selector(:image_split)
         # example: https://cdnx.jumpseller.com/store-name/image/13909331/split_string/230/260?1610821805
         node.at_css("img")["src"]&.split("/#{split_string}")&.first
       rescue NoMethodError

--- a/spiders/ecommerce_engines/jumpseller/spider.rb
+++ b/spiders/ecommerce_engines/jumpseller/spider.rb
@@ -16,11 +16,6 @@ module EcommerceEngines
 
       private
 
-      def get_url(node, url)
-        rel_url = node.at_css("a")[:href]
-        absolute_url(rel_url, base: url)
-      end
-
       def get_image_url(node, split_string)
         # example: https://cdnx.jumpseller.com/store-name/image/13909331/split_string/230/260?1610821805
         node.at_css("img")["src"]&.split("/#{split_string}")&.first

--- a/spiders/ecommerce_engines/jumpseller/spider.rb
+++ b/spiders/ecommerce_engines/jumpseller/spider.rb
@@ -21,10 +21,6 @@ module EcommerceEngines
         absolute_url(rel_url, base: url)
       end
 
-      def purchasable?(node)
-        in_stock?(node)
-      end
-
       def get_image_url(node, split_string)
         # example: https://cdnx.jumpseller.com/store-name/image/13909331/split_string/230/260?1610821805
         node.at_css("img")["src"]&.split("/#{split_string}")&.first

--- a/spiders/ecommerce_engines/jumpseller/spider.rb
+++ b/spiders/ecommerce_engines/jumpseller/spider.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module EcommerceEngines
+  module Jumpseller
+    # Base spider class for all stores build with Jumpseller
+    class Spider < ApplicationSpider
+      def parse(response, url:, data: {})
+        items = parse_index(response, url:)
+        items.each { |item| send_item item }
+
+        paginate(response, url)
+      end
+
+      def parse_product_node(node, url:)
+        {
+          url: get_url(node, url),
+          title: get_title(node),
+          price: get_price(node),
+          stock: purchasable?(node),
+          image_url: get_image_url(node)
+        }
+      end
+
+      private
+
+      def get_url(node, url)
+        rel_url = node.at_css("a")[:href]
+        absolute_url(rel_url, base: url)
+      end
+
+      def purchasable?(node)
+        in_stock?(node)
+      end
+
+      def get_image_url(node, split_string)
+        # example: https://cdnx.jumpseller.com/store-name/image/13909331/split_string/230/260?1610821805
+        node.at_css("img")["src"]&.split("/#{split_string}")&.first
+      rescue NoMethodError
+        nil
+      end
+    end
+  end
+end

--- a/spiders/ecommerce_engines/jumpseller/spider.rb
+++ b/spiders/ecommerce_engines/jumpseller/spider.rb
@@ -4,19 +4,9 @@ module EcommerceEngines
   module Jumpseller
     # Base spider class for all stores build with Jumpseller
     class Spider < ApplicationSpider
-      def parse_product_node(node, url:)
-        {
-          url: get_url(node, url),
-          title: get_title(node),
-          price: get_price(node),
-          stock: purchasable?(node),
-          image_url: get_image_url(node)
-        }
-      end
-
       private
 
-      def get_image_url(node)
+      def get_image_url(node, _url)
         split_string = get_selector(:image_split)
         # example: https://cdnx.jumpseller.com/store-name/image/13909331/split_string/230/260?1610821805
         node.at_css("img")["src"]&.split("/#{split_string}")&.first

--- a/spiders/ecommerce_engines/presta_shop/spider.rb
+++ b/spiders/ecommerce_engines/presta_shop/spider.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 module EcommerceEngines
   module PrestaShop
+    # Base spider class for all stores build with PrestaShop
     class Spider < ApplicationSpider
       def parse(response, url:, data: {})
         items = parse_index(response, url:)

--- a/spiders/ecommerce_engines/presta_shop/spider.rb
+++ b/spiders/ecommerce_engines/presta_shop/spider.rb
@@ -45,10 +45,6 @@ module EcommerceEngines
         node.at_css("li.out_of_stock").nil?
       end
 
-      def purchasable?(node)
-        in_stock?(node)
-      end
-
       def get_image_url(node)
         node.at_css("img")["data-full-size-image-url"]
       rescue NoMethodError

--- a/spiders/ecommerce_engines/presta_shop/spider.rb
+++ b/spiders/ecommerce_engines/presta_shop/spider.rb
@@ -1,0 +1,68 @@
+module EcommerceEngines
+  module PrestaShop
+    class Spider < ApplicationSpider
+      def parse(response, url:, data: {})
+        items = parse_index(response, url:)
+        items.each { |item| send_item item }
+
+        paginate(response, url)
+      end
+
+      def parse_index(response, url:, data: {})
+        listings = response.css("div#js-product-list article")
+        listings.map { |listing| parse_product_node(listing, url:) }
+      end
+
+      def parse_product_node(node, url:)
+        {
+          url: get_url(node),
+          title: get_title(node),
+          price: get_price(node),
+          stock: purchasable?(node),
+          image_url: get_image_url(node)
+        }
+      end
+
+      def next_page_url(response, url)
+        next_page_node = response.at_css("nav.pagination li a[@rel=next]")
+        return unless next_page_node
+
+        absolute_url(next_page_node[:href], base: url)
+      end
+
+      private
+
+      def paginate(response, url)
+        next_page_url = next_page_url(response, url)
+        request_to(:parse, url: next_page_url) if next_page_url
+      end
+
+      def get_url(node)
+        node.at_css(".product-title a")[:href]
+      end
+
+      def get_title(node)
+        node.at_css(".product-title").text.strip
+      end
+
+      def get_price(node)
+        price_node = node.at_css("span.price")
+        scan_int(price_node.text) if price_node
+      end
+
+      def in_stock?(node)
+        node.at_css("li.out_of_stock").nil?
+      end
+
+      def purchasable?(node)
+        in_stock?(node)
+      end
+
+      def get_image_url(node)
+        node.at_css("img")["data-full-size-image-url"]
+      rescue NoMethodError
+        nil
+      end
+    end
+  end
+end

--- a/spiders/ecommerce_engines/presta_shop/spider.rb
+++ b/spiders/ecommerce_engines/presta_shop/spider.rb
@@ -9,24 +9,11 @@ module EcommerceEngines
       selector :title, ".product-title"
       selector :price, "span.price"
       selector :stock, "li.out_of_stock"
-
-      def parse_product_node(node, url:)
-        {
-          url: get_url(node),
-          title: get_title(node),
-          price: get_price(node),
-          stock: purchasable?(node),
-          image_url: get_image_url(node)
-        }
-      end
+      selector :url, ".product-title a"
 
       private
 
-      def get_url(node)
-        node.at_css(".product-title a")[:href]
-      end
-
-      def get_image_url(node)
+      def get_image_url(node, _url)
         node.at_css("img")["data-full-size-image-url"]
       rescue NoMethodError
         nil

--- a/spiders/ecommerce_engines/presta_shop/spider.rb
+++ b/spiders/ecommerce_engines/presta_shop/spider.rb
@@ -4,10 +4,11 @@ module EcommerceEngines
   module PrestaShop
     # Base spider class for all stores build with PrestaShop
     class Spider < ApplicationSpider
-      def parse_index(response, url:, data: {})
-        listings = response.css("div#js-product-list article")
-        listings.map { |listing| parse_product_node(listing, url:) }
-      end
+      selector :index_product, "div#js-product-list article"
+      selector :next_page, "nav.pagination li a[@rel=next]"
+      selector :title, ".product-title"
+      selector :price, "span.price"
+      selector :stock, "li.out_of_stock"
 
       def parse_product_node(node, url:)
         {
@@ -19,30 +20,10 @@ module EcommerceEngines
         }
       end
 
-      def next_page_url(response, url)
-        next_page_node = response.at_css("nav.pagination li a[@rel=next]")
-        return unless next_page_node
-
-        absolute_url(next_page_node[:href], base: url)
-      end
-
       private
 
       def get_url(node)
         node.at_css(".product-title a")[:href]
-      end
-
-      def get_title(node)
-        node.at_css(".product-title").text.strip
-      end
-
-      def get_price(node)
-        price_node = node.at_css("span.price")
-        scan_int(price_node.text) if price_node
-      end
-
-      def in_stock?(node)
-        node.at_css("li.out_of_stock").nil?
       end
 
       def get_image_url(node)

--- a/spiders/ecommerce_engines/presta_shop/spider.rb
+++ b/spiders/ecommerce_engines/presta_shop/spider.rb
@@ -28,11 +28,6 @@ module EcommerceEngines
 
       private
 
-      def paginate(response, url)
-        next_page_url = next_page_url(response, url)
-        request_to(:parse, url: next_page_url) if next_page_url
-      end
-
       def get_url(node)
         node.at_css(".product-title a")[:href]
       end

--- a/spiders/ecommerce_engines/presta_shop/spider.rb
+++ b/spiders/ecommerce_engines/presta_shop/spider.rb
@@ -4,13 +4,6 @@ module EcommerceEngines
   module PrestaShop
     # Base spider class for all stores build with PrestaShop
     class Spider < ApplicationSpider
-      def parse(response, url:, data: {})
-        items = parse_index(response, url:)
-        items.each { |item| send_item item }
-
-        paginate(response, url)
-      end
-
       def parse_index(response, url:, data: {})
         listings = response.css("div#js-product-list article")
         listings.map { |listing| parse_product_node(listing, url:) }

--- a/spiders/ecommerce_engines/shopify/spider.rb
+++ b/spiders/ecommerce_engines/shopify/spider.rb
@@ -4,10 +4,7 @@ module EcommerceEngines
   module Shopify
     # Base spider class for all stores build with Shopify
     class Spider < ApplicationSpider
-      def parse_index(response, url:, selector:, data: {})
-        listings = response.css(selector)
-        listings.map { |listing| parse_product_node(listing, url:) }
-      end
+      selector :url, "a"
 
       def parse_product_node(node, url:)
         {
@@ -17,35 +14,6 @@ module EcommerceEngines
           stock: purchasable?(node),
           image_url: get_image_url(node)
         }
-      end
-
-      def next_page_url(response, url, selector)
-        next_page_node = response.at_css(selector)
-        return unless next_page_node
-
-        absolute_url(next_page_node[:href], base: url)
-      end
-
-      private
-
-      def get_url(node, url)
-        rel_url = node.at_css("a")[:href]
-        absolute_url(rel_url, base: url)
-      end
-
-      def get_title(node, selector)
-        node.at_css(selector).text.strip
-      end
-
-      def get_price(node, selector)
-        price_node = node.at_css(selector)
-        return unless price_node
-
-        scan_int(price_node.text)
-      end
-
-      def in_stock?(node, selector)
-        node.at_css(selector).nil?
       end
 
       def format_image_url(url)

--- a/spiders/ecommerce_engines/shopify/spider.rb
+++ b/spiders/ecommerce_engines/shopify/spider.rb
@@ -6,16 +6,6 @@ module EcommerceEngines
     class Spider < ApplicationSpider
       selector :url, "a"
 
-      def parse_product_node(node, url:)
-        {
-          url: get_url(node, url),
-          title: get_title(node),
-          price: get_price(node),
-          stock: purchasable?(node),
-          image_url: get_image_url(node)
-        }
-      end
-
       def format_image_url(url)
         uri = URI.parse(url)
         uri.scheme = "https"

--- a/spiders/ecommerce_engines/shopify/spider.rb
+++ b/spiders/ecommerce_engines/shopify/spider.rb
@@ -48,10 +48,6 @@ module EcommerceEngines
         node.at_css(selector).nil?
       end
 
-      def purchasable?(node)
-        in_stock?(node)
-      end
-
       def format_image_url(url)
         uri = URI.parse(url)
         uri.scheme = "https"

--- a/spiders/ecommerce_engines/shopify/spider.rb
+++ b/spiders/ecommerce_engines/shopify/spider.rb
@@ -28,11 +28,6 @@ module EcommerceEngines
 
       private
 
-      def paginate(response, url)
-        next_page_url = next_page_url(response, url)
-        request_to(:parse, url: next_page_url) if next_page_url
-      end
-
       def get_url(node, url)
         rel_url = node.at_css("a")[:href]
         absolute_url(rel_url, base: url)

--- a/spiders/ecommerce_engines/shopify/spider.rb
+++ b/spiders/ecommerce_engines/shopify/spider.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module EcommerceEngines
+  module Shopify
+    # Base spider class for all stores build with Shopify
+    class Spider < ApplicationSpider
+      def parse(response, url:, data: {})
+        items = parse_index(response, url:)
+        items.each { |item| send_item item }
+
+        paginate(response, url)
+      end
+
+      def parse_index(response, url:, selector:, data: {})
+        listings = response.css(selector)
+        listings.map { |listing| parse_product_node(listing, url:) }
+      end
+
+      def parse_product_node(node, url:)
+        {
+          url: get_url(node, url),
+          title: get_title(node),
+          price: get_price(node),
+          stock: purchasable?(node),
+          image_url: get_image_url(node)
+        }
+      end
+
+      def next_page_url(response, url, selector)
+        next_page_node = response.at_css(selector)
+        return unless next_page_node
+
+        absolute_url(next_page_node[:href], base: url)
+      end
+
+      private
+
+      def paginate(response, url)
+        next_page_url = next_page_url(response, url)
+        request_to(:parse, url: next_page_url) if next_page_url
+      end
+
+      def get_url(node, url)
+        rel_url = node.at_css("a")[:href]
+        absolute_url(rel_url, base: url)
+      end
+
+      def get_title(node, selector)
+        node.at_css(selector).text.strip
+      end
+
+      def get_price(node, selector)
+        price_node = node.at_css(selector)
+        return unless price_node
+
+        scan_int(price_node.text)
+      end
+
+      def in_stock?(node, selector)
+        node.at_css(selector).nil?
+      end
+
+      def purchasable?(node)
+        in_stock?(node)
+      end
+
+      def format_image_url(url)
+        uri = URI.parse(url)
+        uri.scheme = "https"
+        uri.query = nil
+        uri.to_s
+      end
+    end
+  end
+end

--- a/spiders/ecommerce_engines/shopify/spider.rb
+++ b/spiders/ecommerce_engines/shopify/spider.rb
@@ -4,13 +4,6 @@ module EcommerceEngines
   module Shopify
     # Base spider class for all stores build with Shopify
     class Spider < ApplicationSpider
-      def parse(response, url:, data: {})
-        items = parse_index(response, url:)
-        items.each { |item| send_item item }
-
-        paginate(response, url)
-      end
-
       def parse_index(response, url:, selector:, data: {})
         listings = response.css(selector)
         listings.map { |listing| parse_product_node(listing, url:) }

--- a/spiders/ecommerce_engines/woo_commerce/spider.rb
+++ b/spiders/ecommerce_engines/woo_commerce/spider.rb
@@ -1,0 +1,68 @@
+module EcommerceEngines
+  module WooCommerce
+    class Spider < ApplicationSpider
+      def parse(response, url:, data: {})
+        items = parse_index(response, url:)
+        items.each { |item| send_item item }
+
+        paginate(response, url)
+      end
+
+      def parse_index(response, url:, data: {})
+        listings = response.css("ul.products li.product")
+        listings.map { |listing| parse_product_node(listing, url:) }
+      end
+
+      def next_page_url(response, url)
+        next_page = response.at_css("nav.woocommerce-pagination li a.next")
+        return unless next_page
+
+        absolute_url(next_page[:href], base: url)
+      end
+
+      def parse_product_node(node, url:)
+        {
+          url: get_url(node),
+          title: get_title(node),
+          price: get_price(node),
+          stock: purchasable?(node),
+          image_url: get_image_url(node)
+        }
+      end
+
+      private
+
+      def paginate(response, url)
+        next_page_url = next_page_url(response, url)
+        request_to(:parse, url: next_page_url) if next_page_url
+      end
+
+      def get_url(node)
+        node.at_css("a")[:href]
+      end
+
+      def get_title(node)
+        node.at_css("h2").text.strip
+      end
+
+      def get_price(node)
+        price_node = node.css("span.price bdi").last
+        scan_int(price_node.text) if price_node
+      end
+
+      def in_stock?(node)
+        !node.classes.include?("outofstock")
+      end
+
+      def purchasable?(node)
+        in_stock?(node)
+      end
+
+      def get_image_url(node)
+        node.at_css("img")["srcset"].split(",").last.split.first
+      rescue NoMethodError
+        nil
+      end
+    end
+  end
+end

--- a/spiders/ecommerce_engines/woo_commerce/spider.rb
+++ b/spiders/ecommerce_engines/woo_commerce/spider.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 module EcommerceEngines
   module WooCommerce
+    # Base spider class for all stores build with WooCommerce
     class Spider < ApplicationSpider
       class << self
         attr_reader :img_url_strategy

--- a/spiders/ecommerce_engines/woo_commerce/spider.rb
+++ b/spiders/ecommerce_engines/woo_commerce/spider.rb
@@ -14,13 +14,6 @@ module EcommerceEngines
         end
       end
 
-      def parse(response, url:, data: {})
-        items = parse_index(response, url:)
-        items.each { |item| send_item item }
-
-        paginate(response, url)
-      end
-
       def parse_index(response, url:, data: {})
         listings = response.css("ul.products li.product")
         listings.map { |listing| parse_product_node(listing, url:) }

--- a/spiders/ecommerce_engines/woo_commerce/spider.rb
+++ b/spiders/ecommerce_engines/woo_commerce/spider.rb
@@ -17,22 +17,9 @@ module EcommerceEngines
       selector :index_product, "ul.products li.product"
       selector :next_page, "nav.woocommerce-pagination li a.next"
       selector :title, "h2"
-
-      def parse_product_node(node, url:)
-        {
-          url: get_url(node),
-          title: get_title(node),
-          price: get_price(node),
-          stock: purchasable?(node),
-          image_url: get_image_url(node)
-        }
-      end
+      selector :url, "a"
 
       private
-
-      def get_url(node)
-        node.at_css("a")[:href]
-      end
 
       def get_price(node)
         price_node = node.css("span.price bdi").last
@@ -43,7 +30,7 @@ module EcommerceEngines
         !node.classes.include?("outofstock")
       end
 
-      def get_image_url(node)
+      def get_image_url(node, _url)
         case self.class.img_url_strategy
         when :srcset
           image_url_from_srcset(node)

--- a/spiders/ecommerce_engines/woo_commerce/spider.rb
+++ b/spiders/ecommerce_engines/woo_commerce/spider.rb
@@ -14,17 +14,9 @@ module EcommerceEngines
         end
       end
 
-      def parse_index(response, url:, data: {})
-        listings = response.css("ul.products li.product")
-        listings.map { |listing| parse_product_node(listing, url:) }
-      end
-
-      def next_page_url(response, url)
-        next_page = response.at_css("nav.woocommerce-pagination li a.next")
-        return unless next_page
-
-        absolute_url(next_page[:href], base: url)
-      end
+      selector :index_product, "ul.products li.product"
+      selector :next_page, "nav.woocommerce-pagination li a.next"
+      selector :title, "h2"
 
       def parse_product_node(node, url:)
         {
@@ -40,10 +32,6 @@ module EcommerceEngines
 
       def get_url(node)
         node.at_css("a")[:href]
-      end
-
-      def get_title(node)
-        node.at_css("h2").text.strip
       end
 
       def get_price(node)

--- a/spiders/ecommerce_engines/woo_commerce/spider.rb
+++ b/spiders/ecommerce_engines/woo_commerce/spider.rb
@@ -38,11 +38,6 @@ module EcommerceEngines
 
       private
 
-      def paginate(response, url)
-        next_page_url = next_page_url(response, url)
-        request_to(:parse, url: next_page_url) if next_page_url
-      end
-
       def get_url(node)
         node.at_css("a")[:href]
       end

--- a/spiders/ecommerce_engines/woo_commerce/spider.rb
+++ b/spiders/ecommerce_engines/woo_commerce/spider.rb
@@ -55,10 +55,6 @@ module EcommerceEngines
         !node.classes.include?("outofstock")
       end
 
-      def purchasable?(node)
-        in_stock?(node)
-      end
-
       def get_image_url(node)
         case self.class.img_url_strategy
         when :srcset

--- a/spiders/el_dado_spider.rb
+++ b/spiders/el_dado_spider.rb
@@ -15,14 +15,5 @@ class ElDadoSpider < EcommerceEngines::WooCommerce::Spider
     listings.map { |listing| parse_product_node(listing, url:) }
   end
 
-  def get_image_url(node)
-    # Example: https://eldado.cl/wp-content/uploads/2024/09/pw-gift-card-150x150.png
-    full_url = node.at_css("img")["src"]
-    match = full_url.match(/(?<base>.+?)(?<size>-\d+x\d+)?(?<ext>\.\w+)$/)
-    return unless match
-
-    "#{match[:base]}#{match[:ext]}"
-  rescue NoMethodError
-    nil
-  end
+  image_url_strategy(:sized)
 end

--- a/spiders/el_dado_spider.rb
+++ b/spiders/el_dado_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # El Dado store spider
-# engine: woocomerce
-class ElDadoSpider < ApplicationSpider
+class ElDadoSpider < EcommerceEngines::WooCommerce::Spider
   @name = "el_dado_spider"
   @store = {
     name: "El Dado",
@@ -11,63 +10,9 @@ class ElDadoSpider < ApplicationSpider
   @start_urls = ["https://eldado.cl/catalogo-de-juegos"]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
   def parse_index(response, url:, data: {})
     listings = response.css("div.product-grid-items div.product-type-simple")
     listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("nav.woocommerce-pagination li a.next")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
-
-  private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node)
-    node.at_css("a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css("h2").text.strip
-  end
-
-  def get_price(node)
-    price_node = node.css("span.price bdi").last
-    # somehow there are no prices on some items...
-    # ex: https://eldado.cl/producto/dobble-31-minutos/ (10/05/2025)
-    scan_int(price_node.text) if price_node
-  end
-
-  def in_stock?(node)
-    node.classes.include?("instock")
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
   end
 
   def get_image_url(node)

--- a/spiders/el_dado_spider.rb
+++ b/spiders/el_dado_spider.rb
@@ -10,10 +10,7 @@ class ElDadoSpider < EcommerceEngines::WooCommerce::Spider
   @start_urls = ["https://eldado.cl/catalogo-de-juegos"]
   @config = {}
 
-  def parse_index(response, url:, data: {})
-    listings = response.css("div.product-grid-items div.product-type-simple")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
+  selector :index_product, "div.product-grid-items div.product-type-simple"
 
   image_url_strategy(:sized)
 end

--- a/spiders/el_patio_geek_spider.rb
+++ b/spiders/el_patio_geek_spider.rb
@@ -10,23 +10,12 @@ class ElPatioGeekSpider < EcommerceEngines::Shopify::Spider
   @start_urls = ["https://www.elpatiogeek.cl/collections/all"]
   @config = {}
 
-  def parse_index(response, url:, data: {})
-    super(response, url:, selector: "div.grid-uniform div.grid-item")
-  end
-
-  def next_page_url(response, url)
-    super(response, url, "ul.pagination-custom li:last-child a")
-  end
+  selector :index_product, "div.grid-uniform div.grid-item"
+  selector :next_page, "ul.pagination-custom li:last-child a"
+  selector :title, "p"
+  selector :price, "div.product-item--price small"
 
   private
-
-  def get_title(node)
-    super(node, "p")
-  end
-
-  def get_price(node)
-    super(node, "div.product-item--price small")
-  end
 
   def purchasable?(_node)
     true

--- a/spiders/el_patio_geek_spider.rb
+++ b/spiders/el_patio_geek_spider.rb
@@ -21,7 +21,7 @@ class ElPatioGeekSpider < EcommerceEngines::Shopify::Spider
     true
   end
 
-  def get_image_url(node)
+  def get_image_url(node, _url)
     url = node.at_css("img")["srcset"].split[-2]
     format_image_url(url)
   rescue NoMethodError

--- a/spiders/enroque_spider.rb
+++ b/spiders/enroque_spider.rb
@@ -22,7 +22,7 @@ class EnroqueSpider < EcommerceEngines::Shopify::Spider
 
   private
 
-  def get_image_url(node)
+  def get_image_url(node, _url)
     url = node.at_css("img")["data-src"]
     format_image_url(url)
   rescue NoMethodError

--- a/spiders/enroque_spider.rb
+++ b/spiders/enroque_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Enroque store spider
-# Engine: shopify
-class EnroqueSpider < ApplicationSpider
+class EnroqueSpider < EcommerceEngines::Shopify::Spider
   @name = "enroque_spider"
   @store = {
     name: "enroque",
@@ -15,69 +14,31 @@ class EnroqueSpider < ApplicationSpider
   ]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
   def parse_index(response, url:, data: {})
-    listings = response.css("div#filter-results li.js-pagination-result")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node, url),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
+    super(response, url:, selector: "div#filter-results li.js-pagination-result")
   end
 
   def next_page_url(response, url)
-    next_page = response.at_css("nav ul.pagination li:last-child a")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
+    super(response, url, "nav ul.pagination li:last-child a")
   end
 
   private
 
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node, url)
-    absolute_url(node.at_css("a.card-link")[:href], base: url)
-  end
-
   def get_title(node)
-    node.at_css("a.card-link").text
+    super(node, "a.card-link")
   end
 
   def get_price(node)
-    price_node = node.at_css("strong.price__current")
-    scan_int(price_node.text)
+    super(node, "strong.price__current")
   end
 
   def in_stock?(node)
-    node.at_css("span.product-label--sold-out").nil?
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
+    super(node, "span.product-label--sold-out")
   end
 
   def get_image_url(node)
     url = node.at_css("img")["data-src"]
-    uri = URI.parse(url)
-    uri.query = nil
-    uri.scheme = "https"
-    uri.to_s
+    format_image_url(url)
   rescue NoMethodError
     nil
   end

--- a/spiders/enroque_spider.rb
+++ b/spiders/enroque_spider.rb
@@ -14,27 +14,13 @@ class EnroqueSpider < EcommerceEngines::Shopify::Spider
   ]
   @config = {}
 
-  def parse_index(response, url:, data: {})
-    super(response, url:, selector: "div#filter-results li.js-pagination-result")
-  end
-
-  def next_page_url(response, url)
-    super(response, url, "nav ul.pagination li:last-child a")
-  end
+  selector :index_product, "div#filter-results li.js-pagination-result"
+  selector :next_page, "nav ul.pagination li:last-child a"
+  selector :title, "a.card-link"
+  selector :price, "strong.price__current"
+  selector :stock, "span.product-label--sold-out"
 
   private
-
-  def get_title(node)
-    super(node, "a.card-link")
-  end
-
-  def get_price(node)
-    super(node, "strong.price__current")
-  end
-
-  def in_stock?(node)
-    super(node, "span.product-label--sold-out")
-  end
 
   def get_image_url(node)
     url = node.at_css("img")["data-src"]

--- a/spiders/entrejuegos_spider.rb
+++ b/spiders/entrejuegos_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Entrejuegos  store spider
-# engine: prestashop
-class EntrejuegosSpider < ApplicationSpider
+class EntrejuegosSpider < EcommerceEngines::PrestaShop::Spider
   @name = "entrejuegos_spider"
   @store = {
     name: "Entrejuegos",
@@ -11,59 +10,11 @@ class EntrejuegosSpider < ApplicationSpider
   @start_urls = ["https://www.entrejuegos.cl/1064-juegos-de-mesa?page=1"]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("div#js-product-list article")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page_node = response.at_css("nav.pagination li a[@rel=next]")
-    return unless next_page_node
-
-    absolute_url(next_page_node[:href], base: url)
-  end
-
   private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node)
-    node.at_css(".product-title a")[:href]
-  end
 
   def get_title(node)
     url = node.at_css("img")[:src]
     File.basename(url, ".jpg").gsub("-", " ")
-  end
-
-  def get_price(node)
-    price_node = node.at_css("span.price")
-    scan_int(price_node.text) if price_node
-  end
-
-  def in_stock?(node)
-    out_of_stock_banner = node.at_css("li.out_of_stock")
-    out_of_stock_banner.nil?
   end
 
   def price?(node)
@@ -78,11 +29,5 @@ class EntrejuegosSpider < ApplicationSpider
 
   def purchasable?(node)
     in_stock?(node) && price?(node)
-  end
-
-  def get_image_url(node)
-    node.at_css("img")["data-full-size-image-url"]
-  rescue NoMethodError
-    nil
   end
 end

--- a/spiders/flexogames_spider.rb
+++ b/spiders/flexogames_spider.rb
@@ -21,7 +21,7 @@ class FlexogamesSpider < EcommerceEngines::Shopify::Spider
   # TODO: This store loads product images lazily.
   # The data-srcset attribute is not immediately available when using the Mechanize engine.
   # It doesn't work with SeleniumChrome either. We need to find a way to trigger the image load.
-  def get_image_url(_node)
+  def get_image_url(_node, _url)
     nil
   end
 end

--- a/spiders/flexogames_spider.rb
+++ b/spiders/flexogames_spider.rb
@@ -10,27 +10,13 @@ class FlexogamesSpider < EcommerceEngines::Shopify::Spider
   @start_urls = ["https://www.flexogames.cl/collections/juegos-de-mesa"]
   @config = {}
 
-  def parse_index(response, url:, data: {})
-    super(response, url:, selector: "div#Collection ul.grid li", data:)
-  end
-
-  def next_page_url(response, url)
-    super(response, url, "ul.pagination li:last-child a")
-  end
+  selector :index_product, "div#Collection ul.grid li"
+  selector :next_page, "ul.pagination li:last-child a"
+  selector :title, "a span"
+  selector :price, "dl span.price-item"
+  selector :stock, "dl.price--sold-out"
 
   private
-
-  def get_title(node)
-    super(node, "a span")
-  end
-
-  def get_price(node)
-    super(node, "dl span.price-item")
-  end
-
-  def in_stock?(node)
-    super(node, "dl.price--sold-out")
-  end
 
   # TODO: This store loads product images lazily.
   # The data-srcset attribute is not immediately available when using the Mechanize engine.

--- a/spiders/guildreams_spider.rb
+++ b/spiders/guildreams_spider.rb
@@ -10,29 +10,12 @@ class GuildreamsSpider < EcommerceEngines::Bsale::Spider
   @start_urls = ["https://www.guildreams.com/collection/juegos-de-mesa?order=id&way=DESC&limit=24&page=1"]
   @config = {}
 
-  def parse_index(response, url:, data: {})
-    super(response, url:, selector: "div.bs-product")
-  end
-
-  def next_page_url(response, url)
-    super(response, url, "ul.pagination li:last-child a.page-link[data-nf]")
-  end
-
-  private
-
-  def get_title(node)
-    node.at_css("h2").text.strip
-  end
-
-  def get_price(node)
-    super(node, "div.bs-product-final-price")
-  end
-
-  def in_stock?(node)
-    super(node, "div.bs-stock")
-  end
-
-  def get_image_url(node)
-    super(node, "data-src")
-  end
+  selector :index_product, "div.bs-product"
+  selector :next_page, "ul.pagination li:last-child a.page-link[data-nf]"
+  selector :title, "h2"
+  selector :stock, "div.bs-stock"
+  selector :price, "div.bs-product-final-price"
+  selector :url, "a"
+  selector :image_tag, "img"
+  selector :image_attr, "data-src"
 end

--- a/spiders/la_fortaleza_spider.rb
+++ b/spiders/la_fortaleza_spider.rb
@@ -10,23 +10,13 @@ class LaFortalezaSpider < EcommerceEngines::Jumpseller::Spider
   @start_urls = ["https://www.lafortalezapuq.cl/jdm"]
   @config = {}
 
-  def parse_index(response, url:, data: {})
-    listings = response.css("div.products figure.product")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def next_page_url(response, url)
-    next_page_node = response.at_css("nav.pagination-next-prev a[@class=next]")
-    return unless next_page_node
-
-    absolute_url(next_page_node[:href], base: url)
-  end
+  selector :index_product, "div.products figure.product"
+  selector :next_page, "nav.pagination-next-prev a[@class=next]"
+  selector :url, "a"
+  selector :title, "h5"
+  selector :stock, "div.product-out-of-stock"
 
   private
-
-  def get_title(node)
-    node.at_css("h5").text
-  end
 
   def discount_price(node)
     node.at_css("span.product-price-discount i")
@@ -39,10 +29,6 @@ class LaFortalezaSpider < EcommerceEngines::Jumpseller::Spider
   def get_price(node)
     price_node = discount_price(node) || regular_price(node)
     scan_int(price_node.text) if price_node
-  end
-
-  def in_stock?(node)
-    node.at_css("div.product-out-of-stock").nil?
   end
 
   def get_image_url(node)

--- a/spiders/la_fortaleza_spider.rb
+++ b/spiders/la_fortaleza_spider.rb
@@ -15,6 +15,7 @@ class LaFortalezaSpider < EcommerceEngines::Jumpseller::Spider
   selector :url, "a"
   selector :title, "h5"
   selector :stock, "div.product-out-of-stock"
+  selector :image_split, "thumb"
 
   private
 
@@ -29,9 +30,5 @@ class LaFortalezaSpider < EcommerceEngines::Jumpseller::Spider
   def get_price(node)
     price_node = discount_price(node) || regular_price(node)
     scan_int(price_node.text) if price_node
-  end
-
-  def get_image_url(node)
-    super(node, "thumb")
   end
 end

--- a/spiders/la_fortaleza_spider.rb
+++ b/spiders/la_fortaleza_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # La Fortaleza store spider
-# engine: jumpseller
-class LaFortalezaSpider < ApplicationSpider
+class LaFortalezaSpider < EcommerceEngines::Jumpseller::Spider
   @name = "la_fortaleza_spider"
   @store = {
     name: "La Fortaleza",
@@ -11,26 +10,9 @@ class LaFortalezaSpider < ApplicationSpider
   @start_urls = ["https://www.lafortalezapuq.cl/jdm"]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
   def parse_index(response, url:, data: {})
-    nodes = response.css("div.products figure.product")
-    nodes.map { |node| parse_product_node(node, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node, url),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
+    listings = response.css("div.products figure.product")
+    listings.map { |listing| parse_product_node(listing, url:) }
   end
 
   def next_page_url(response, url)
@@ -42,24 +24,20 @@ class LaFortalezaSpider < ApplicationSpider
 
   private
 
-  def paginate(response, url)
-    next_url = next_page_url(response, url)
-    request_to(:parse, url: next_url) if next_url
-  end
-
-  def get_url(node, url)
-    rel_url = node.at_css("a")[:href]
-    absolute_url(rel_url, base: url)
-  end
-
   def get_title(node)
     node.at_css("h5").text
   end
 
+  def discount_price(node)
+    node.at_css("span.product-price-discount i")
+  end
+
+  def regular_price(node)
+    node.at_css("span.product-price")
+  end
+
   def get_price(node)
-    discount_node = node.at_css("span.product-price-discount i")
-    regular_node = node.at_css("span.product-price")
-    price_node = discount_node || regular_node
+    price_node = discount_price(node) || regular_price(node)
     scan_int(price_node.text) if price_node
   end
 
@@ -67,14 +45,7 @@ class LaFortalezaSpider < ApplicationSpider
     node.at_css("div.product-out-of-stock").nil?
   end
 
-  def purchasable?(node)
-    in_stock?(node)
-  end
-
   def get_image_url(node)
-    # example: https://cdnx.jumpseller.com/la-fortaleza-punta-arenas1/image/13909331/thumb/230/260?1610821805
-    node.at_css("img")[:src]&.split("/thumb")&.first
-  rescue NoMethodError
-    nil
+    super(node, "thumb")
   end
 end

--- a/spiders/la_loseta_spider.rb
+++ b/spiders/la_loseta_spider.rb
@@ -10,16 +10,5 @@ class LaLosetaSpider < EcommerceEngines::WooCommerce::Spider
   @start_urls = ["https://laloseta.cl/catalogo/swoof1/product_cat-juego-de-mesa/instock/"]
   @config = {}
 
-  private
-
-  def get_image_url(node)
-    # Example: https://laloseta.cl/wp-content/uploads/woocommerce-placeholder-300x300.png
-    full_url = node.at_css("img")["src"]
-    match = full_url.match(/(?<url>.*)(?<size>-\d+x\d+)(?<ext>\..*)/)
-    return unless match
-
-    "#{match[:url]}#{match[:ext]}"
-  rescue NoMethodError
-    nil
-  end
+  image_url_strategy(:sized)
 end

--- a/spiders/la_loseta_spider.rb
+++ b/spiders/la_loseta_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # La Loseta store spider
-# Engine: woocommerce
-class LaLosetaSpider < ApplicationSpider
+class LaLosetaSpider < EcommerceEngines::WooCommerce::Spider
   @name = "la_loseta_spider"
   @store = {
     name: "La Loseta",
@@ -11,63 +10,7 @@ class LaLosetaSpider < ApplicationSpider
   @start_urls = ["https://laloseta.cl/catalogo/swoof1/product_cat-juego-de-mesa/instock/"]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("ul.products li.product")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("nav.woocommerce-pagination li a.next")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
-
   private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node)
-    node.at_css("a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css("h2").text.strip
-  end
-
-  def get_price(node)
-    # TODO: verify how a discounted listings prices are displayed.
-    price_node = node.css("span.price bdi").last
-    scan_int(price_node.text) if price_node
-  end
-
-  def in_stock?(node)
-    !node.at_css("a.add_to_cart_button").nil?
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
-  end
 
   def get_image_url(node)
     # Example: https://laloseta.cl/wp-content/uploads/woocommerce-placeholder-300x300.png

--- a/spiders/la_teka_spider.rb
+++ b/spiders/la_teka_spider.rb
@@ -10,28 +10,13 @@ class LaTekaSpider < EcommerceEngines::Shopify::Spider
   @start_urls = ["https://lateka.cl/collections/juegos-de-mesa?filter.v.availability=1"]
   @config = {}
 
-  def parse_index(response, url:, data: {})
-    super(response, url:, data:, selector: "ul#product-grid div.card")
-  end
-
-  def next_page_url(response, url)
-    # yes, the store has backward styles for next and prev links...
-    super(response, url, "nav.pagination a.pagination__item--prev")
-  end
+  selector :index_product, "ul#product-grid div.card"
+  selector :next_page, "nav.pagination a.pagination__item--prev"
+  selector :title, "h3"
+  selector :price, "span.price-item--sale"
+  selector :stock, "product-form button[disabled]"
 
   private
-
-  def get_title(node)
-    super(node, "h3")
-  end
-
-  def get_price(node)
-    super(node, "span.price-item--sale")
-  end
-
-  def in_stock?(node)
-    super(node, "product-form button[disabled]")
-  end
 
   def get_image_url(node)
     url = node.at_css("img")["src"]

--- a/spiders/la_teka_spider.rb
+++ b/spiders/la_teka_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # La Teka store spider
-# engine: Shopify
-class LaTekaSpider < ApplicationSpider
+class LaTekaSpider < EcommerceEngines::Shopify::Spider
   @name = "la_teka_spider"
   @store = {
     name: "La Teka",
@@ -11,71 +10,32 @@ class LaTekaSpider < ApplicationSpider
   @start_urls = ["https://lateka.cl/collections/juegos-de-mesa?filter.v.availability=1"]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
   def parse_index(response, url:, data: {})
-    listings = response.css("ul#product-grid div.card")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node, url),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
+    super(response, url:, data:, selector: "ul#product-grid div.card")
   end
 
   def next_page_url(response, url)
     # yes, the store has backward styles for next and prev links...
-    next_page = response.at_css("nav.pagination a.pagination__item--prev")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
+    super(response, url, "nav.pagination a.pagination__item--prev")
   end
 
   private
 
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node, url)
-    rel_url = node.at_css("h3 a")[:href]
-    absolute_url(rel_url, base: url)
-  end
-
   def get_title(node)
-    node.at_css("h3").text.strip
+    super(node, "h3")
   end
 
   def get_price(node)
-    price_node = node.at_css("span.price-item--sale")
-    scan_int(price_node.text)
+    super(node, "span.price-item--sale")
   end
 
   def in_stock?(node)
-    node.at_css("product-form button")["disabled"].nil?
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
+    super(node, "product-form button[disabled]")
   end
 
   def get_image_url(node)
     url = node.at_css("img")["src"]
-    uri = URI.parse(url)
-    uri.scheme = "https"
-    uri.query = nil
-    uri.to_s
+    format_image_url(url)
   rescue NoMethodError
     nil
   end

--- a/spiders/la_teka_spider.rb
+++ b/spiders/la_teka_spider.rb
@@ -18,7 +18,7 @@ class LaTekaSpider < EcommerceEngines::Shopify::Spider
 
   private
 
-  def get_image_url(node)
+  def get_image_url(node, _url)
     url = node.at_css("img")["src"]
     format_image_url(url)
   rescue NoMethodError

--- a/spiders/ludi_spider.rb
+++ b/spiders/ludi_spider.rb
@@ -10,16 +10,5 @@ class LudiSpider < EcommerceEngines::WooCommerce::Spider
   @start_urls = ["https://www.ludi.cl/tienda"]
   @config = {}
 
-  private
-
-  def get_image_url(node)
-    # Example: https://www.ludi.cl/wp-content/uploads/2025/04/00-8-300x300.jpg
-    full_url = node.at_css("img")["src"]
-    match = full_url.match(/(?<url>.*)(?<size>-\d+x\d+)(?<ext>\..*)/)
-    return unless match
-
-    "#{match[:url]}#{match[:ext]}"
-  rescue NoMethodError
-    nil
-  end
+  image_url_strategy(:sized)
 end

--- a/spiders/ludi_spider.rb
+++ b/spiders/ludi_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Ludi store spider
-# Engine: woocommerce
-class LudiSpider < ApplicationSpider
+class LudiSpider < EcommerceEngines::WooCommerce::Spider
   @name = "ludi_spider"
   @store = {
     name: "Ludi",
@@ -11,62 +10,7 @@ class LudiSpider < ApplicationSpider
   @start_urls = ["https://www.ludi.cl/tienda"]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("ul.products li.product")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("nav.woocommerce-pagination li a.next")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
-
   private
-
-  def paginate(response, url)
-    next_url = next_page_url(response, url)
-    request_to(:parse, url: next_url) if next_url
-  end
-
-  def get_url(node)
-    node.at_css("a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css("h2").text.strip
-  end
-
-  def get_price(node)
-    price_node = node.css("span.price bdi").last
-    scan_int(price_node.text) if price_node
-  end
-
-  def in_stock?(node)
-    node.classes.include?("instock")
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
-  end
 
   def get_image_url(node)
     # Example: https://www.ludi.cl/wp-content/uploads/2025/04/00-8-300x300.jpg

--- a/spiders/magicsur_spider.rb
+++ b/spiders/magicsur_spider.rb
@@ -10,14 +10,6 @@ class MagicsurSpider < EcommerceEngines::PrestaShop::Spider
   @start_urls = ["https://www.magicsur.cl/15-juegos-de-mesa-magicsur-chile"]
   @config = {}
 
-  private
-
-  def get_price(node)
-    price_node = node.at_css("span.product-price")
-    scan_int(price_node.text)
-  end
-
-  def in_stock?(node)
-    !node.at_css("form button.add-to-cart").nil?
-  end
+  selector :price, "span.product-price"
+  selector :stock, "div.product-add-cart a.btn"
 end

--- a/spiders/magicsur_spider.rb
+++ b/spiders/magicsur_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Magicsur store spider
-# Engine: prestashop
-class MagicsurSpider < ApplicationSpider
+class MagicsurSpider < EcommerceEngines::PrestaShop::Spider
   @name = "magicsur_spider"
   @store = {
     name: "magicsur",
@@ -11,49 +10,7 @@ class MagicsurSpider < ApplicationSpider
   @start_urls = ["https://www.magicsur.cl/15-juegos-de-mesa-magicsur-chile"]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("div#js-product-list article")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page_node = response.at_css("nav.pagination li a[@rel=next]")
-    return unless next_page_node
-
-    absolute_url(next_page_node[:href], base: url)
-  end
-
   private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node)
-    node.at_css("h2 a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css("h2").text.strip
-  end
 
   def get_price(node)
     price_node = node.at_css("span.product-price")
@@ -62,15 +19,5 @@ class MagicsurSpider < ApplicationSpider
 
   def in_stock?(node)
     !node.at_css("form button.add-to-cart").nil?
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
-  end
-
-  def get_image_url(node)
-    node.at_css("img")["data-full-size-image-url"]
-  rescue NoMethodError
-    nil
   end
 end

--- a/spiders/piedrabruja_spider.rb
+++ b/spiders/piedrabruja_spider.rb
@@ -42,7 +42,7 @@ class PiedrabrujaSpider < EcommerceEngines::Shopify::Spider
 
   # Since the store has empty nodes at the end of the HTML,
   # we need to rescue from errors when trying to access the :src attribute.
-  def get_image_url(node)
+  def get_image_url(node, _url)
     url = node.at_css("img")["src"]
     format_image_url(url)
   rescue NoMethodError

--- a/spiders/piedrabruja_spider.rb
+++ b/spiders/piedrabruja_spider.rb
@@ -14,9 +14,8 @@ class PiedrabrujaSpider < EcommerceEngines::Shopify::Spider
   @start_urls = ["https://piedrabruja.cl/collections/juegos-de-mesa?page=1"]
   @config = {}
 
-  def parse_index(response, url:, data: {})
-    super(response, url:, data:, selector: "ul#collection li.product-card")
-  end
+  selector :index_product, "ul#collection li.product-card"
+  selector :title, "h3"
 
   def next_page_url(response, url)
     # Each page after the first hast more than one a#load-more-button element... :sigh:
@@ -29,10 +28,6 @@ class PiedrabrujaSpider < EcommerceEngines::Shopify::Spider
   end
 
   private
-
-  def get_title(node)
-    super(node, "h3")
-  end
 
   def get_price(node)
     price_node = node.at_css("p.price").children.last

--- a/spiders/planetaloz_spider.rb
+++ b/spiders/planetaloz_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Planetaloz spider
-# engine: prestashop
-class PlanetalozSpider < ApplicationSpider
+class PlanetalozSpider < EcommerceEngines::PrestaShop::Spider
   @name = "planetaloz_spider"
   @store = {
     name: "Planetaloz",
@@ -11,67 +10,10 @@ class PlanetalozSpider < ApplicationSpider
   @start_urls = ["https://www.planetaloz.cl/14-juegos-de-mesa?q=Disponibilidad-En+stock"]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("div#js-product-list article")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("nav.pagination li a[@rel=next]")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
-
   private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node)
-    node.at_css(".product-title a")[:href]
-  end
 
   def get_title(node)
     url = node.at_css("img")[:src]
     File.basename(url, ".jpg").gsub("-", " ")
-  end
-
-  def get_price(node)
-    price_node = node.at_css("span.price")
-    scan_int(price_node.text)
-  end
-
-  def in_stock?(node)
-    node.at_css("li.out_of_stock").nil?
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
-  end
-
-  def get_image_url(node)
-    node.at_css("img")["data-full-size-image-url"]
-  rescue NoMethodError
-    nil
   end
 end

--- a/spiders/play_kingdom_spider.rb
+++ b/spiders/play_kingdom_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Play Kingdom store spider
-# engine: jumpseller
-class PlayKingdomSpider < ApplicationSpider
+class PlayKingdomSpider < EcommerceEngines::Jumpseller::Spider
   @name = "play_kingdom_spider"
   @store = {
     name: "Play Kingdom",
@@ -11,26 +10,9 @@ class PlayKingdomSpider < ApplicationSpider
   @start_urls = ["https://playkingdom.cl/juegos-de-mesa"]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
   def parse_index(response, url:, data: {})
     listings = response.css("div.row div.product-block")
     listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node, url),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
   end
 
   def next_page_url(response, url)
@@ -41,16 +23,6 @@ class PlayKingdomSpider < ApplicationSpider
   end
 
   private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node, url)
-    rel_url = node.at_css("a")[:href]
-    absolute_url(rel_url, base: url)
-  end
 
   def get_title(node)
     node.at_css("h3 a")[:title]
@@ -65,14 +37,7 @@ class PlayKingdomSpider < ApplicationSpider
     !node.at_css("form button").nil?
   end
 
-  def purchasable?(node)
-    in_stock?(node)
-  end
-
   def get_image_url(node)
-    # example: https://cdnx.jumpseller.com/play-kingdom/image/30309479/resize/300/300?1671209307
-    node.at_css("img")[:src].split("/resize").first
-  rescue NoMethodError
-    nil
+    super(node, "resize")
   end
 end

--- a/spiders/play_kingdom_spider.rb
+++ b/spiders/play_kingdom_spider.rb
@@ -9,32 +9,16 @@ class PlayKingdomSpider < EcommerceEngines::Jumpseller::Spider
   }
   @start_urls = ["https://playkingdom.cl/juegos-de-mesa"]
   @config = {}
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("div.row div.product-block")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("div.category-pager a:last-child[href]")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
+  selector :index_product, "div.row div.product-block"
+  selector :next_page, "div.category-pager a:last-child[href]"
+  selector :price, "div.list-price span:first-child"
+  selector :url, "a"
+  selector :stock, "a.btn.disabled"
 
   private
 
   def get_title(node)
     node.at_css("h3 a")[:title]
-  end
-
-  def get_price(node)
-    price_node = node.at_css("div.list-price span:first-child")
-    scan_int(price_node.text)
-  end
-
-  def in_stock?(node)
-    !node.at_css("form button").nil?
   end
 
   def get_image_url(node)

--- a/spiders/play_kingdom_spider.rb
+++ b/spiders/play_kingdom_spider.rb
@@ -14,14 +14,11 @@ class PlayKingdomSpider < EcommerceEngines::Jumpseller::Spider
   selector :price, "div.list-price span:first-child"
   selector :url, "a"
   selector :stock, "a.btn.disabled"
+  selector :image_split, "resize"
 
   private
 
   def get_title(node)
     node.at_css("h3 a")[:title]
-  end
-
-  def get_image_url(node)
-    super(node, "resize")
   end
 end

--- a/spiders/playcenter_spider.rb
+++ b/spiders/playcenter_spider.rb
@@ -10,14 +10,5 @@ class PlaycenterSpider < EcommerceEngines::WooCommerce::Spider
   @start_urls = ["https://playcenter.cl/categoria-producto/juegos-de-mesa"]
   @config = {}
 
-  def get_image_url(node)
-    # Example: https://playcenter.cl/wp-content/uploads/2025/05/D_NQ_NP_2X_755218-MLC80923289084_122024-F-300x300.webp
-    full_url = node.at_css("img")["src"]
-    match = full_url.match(/(?<url>.*)(?<size>-\d+x\d+)(?<ext>\..*)/)
-    return unless match
-
-    "#{match[:url]}#{match[:ext]}"
-  rescue NoMethodError
-    nil
-  end
+  image_url_strategy(:sized)
 end

--- a/spiders/playcenter_spider.rb
+++ b/spiders/playcenter_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Playcenter store spider
-# Engine: woocommerce
-class PlaycenterSpider < ApplicationSpider
+class PlaycenterSpider < EcommerceEngines::WooCommerce::Spider
   @name = "playcenter_spider"
   @store = {
     name: "Playcenter",
@@ -10,64 +9,6 @@ class PlaycenterSpider < ApplicationSpider
   }
   @start_urls = ["https://playcenter.cl/categoria-producto/juegos-de-mesa"]
   @config = {}
-
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("div.ast-woocommerce-container ul.products li.product")
-
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("nav.woocommerce-pagination li a.next")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
-
-  private
-
-  def paginate(response, url)
-    next_url = next_page_url(response, url)
-    request_to(:parse, url: next_url) if next_url
-  end
-
-  def get_url(node)
-    node.at_css("div.astra-shop-summary-wrap a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css("h2").text.delete_prefix("Juego de Mesa").strip
-  end
-
-  def get_price(node)
-    price_node = node.css("span.price bdi").last
-    scan_int(price_node.text) if price_node
-  end
-
-  def in_stock?(node)
-    node.classes.include?("instock")
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
-  end
 
   def get_image_url(node)
     # Example: https://playcenter.cl/wp-content/uploads/2025/05/D_NQ_NP_2X_755218-MLC80923289084_122024-F-300x300.webp

--- a/spiders/revaruk_spider.rb
+++ b/spiders/revaruk_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Revaruk store spider
-# Engine: woocommerce
-class RevarukSpider < ApplicationSpider
+class RevarukSpider < EcommerceEngines::WooCommerce::Spider
   @name = "revaruk_spider"
   @store = {
     name: "Revaruk",
@@ -10,67 +9,4 @@ class RevarukSpider < ApplicationSpider
   }
   @start_urls = ["https://revaruk.cl/product-category/juegos-de-mesa"]
   @config = {}
-
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("div.ast-woocommerce-container ul.products li.product")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("nav.woocommerce-pagination li a.next")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
-
-  private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node)
-    node.at_css("div.astra-shop-summary-wrap a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css("h2").text.strip
-  end
-
-  def get_price(node)
-    price_node = node.css("span.price bdi").last
-    scan_int(price_node.text) if price_node
-  end
-
-  def in_stock?(node)
-    !node.classes.include?("outofstock")
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
-  end
-
-  def get_image_url(node)
-    node.at_css("img")["data-srcset"].split(", ").last.split.first
-  rescue NoMethodError
-    nil
-  end
 end

--- a/spiders/revaruk_spider.rb
+++ b/spiders/revaruk_spider.rb
@@ -9,4 +9,6 @@ class RevarukSpider < EcommerceEngines::WooCommerce::Spider
   }
   @start_urls = ["https://revaruk.cl/product-category/juegos-de-mesa"]
   @config = {}
+
+  image_url_strategy(:srcset)
 end

--- a/spiders/somos_juegos_spider.rb
+++ b/spiders/somos_juegos_spider.rb
@@ -18,7 +18,7 @@ class SomosJuegosSpider < EcommerceEngines::Shopify::Spider
 
   private
 
-  def get_image_url(node)
+  def get_image_url(node, _url)
     url = node.at_css("img")["data-src"]
     format_image_url(url)
   rescue NoMethodError

--- a/spiders/somos_juegos_spider.rb
+++ b/spiders/somos_juegos_spider.rb
@@ -10,27 +10,13 @@ class SomosJuegosSpider < EcommerceEngines::Shopify::Spider
   @start_urls = ["https://www.somosjuegos.cl/collections/juegos-de-mesa"]
   @config = {}
 
-  def parse_index(response, url:, data: {})
-    super(response, url:, data:, selector: "div#filter-results ul.grid li.js-pagination-result")
-  end
-
-  def next_page_url(response, url)
-    super(response, url, "nav ul.pagination li:last-child a")
-  end
+  selector :index_product, "div#filter-results ul.grid li.js-pagination-result"
+  selector :next_page, "nav ul.pagination li:last-child a"
+  selector :title, "p a"
+  selector :price, "strong.price__current"
+  selector :stock, "span.product-label--sold-out"
 
   private
-
-  def get_title(node)
-    super(node, "p a")
-  end
-
-  def get_price(node)
-    super(node, "strong.price__current")
-  end
-
-  def in_stock?(node)
-    super(node, "span.product-label--sold-out")
-  end
 
   def get_image_url(node)
     url = node.at_css("img")["data-src"]

--- a/spiders/spells_spider.rb
+++ b/spiders/spells_spider.rb
@@ -9,4 +9,6 @@ class SpellsSpider < EcommerceEngines::WooCommerce::Spider
   }
   @start_urls = ["https://spells.cl/categoria-producto/juegos-de-mesa"]
   @config = {}
+
+  image_url_strategy(:srcset)
 end

--- a/spiders/spells_spider.rb
+++ b/spiders/spells_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Spells store spider
-# Engine: woocommerce
-class SpellsSpider < ApplicationSpider
+class SpellsSpider < EcommerceEngines::WooCommerce::Spider
   @name = "spells_spider"
   @store = {
     name: "Spells",
@@ -10,67 +9,4 @@ class SpellsSpider < ApplicationSpider
   }
   @start_urls = ["https://spells.cl/categoria-producto/juegos-de-mesa"]
   @config = {}
-
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("ul.products li.product")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("nav.woocommerce-pagination li a.next")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
-
-  private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node)
-    node.at_css("a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css("h2").text.strip
-  end
-
-  def get_price(node)
-    price_node = node.css("span.price bdi").last
-    scan_int(price_node.text) if price_node
-  end
-
-  def in_stock?(node)
-    node.classes.include?("instock")
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
-  end
-
-  def get_image_url(node)
-    node.at_css("img")["srcset"].split(",").last.split.first
-  rescue NoMethodError
-    nil
-  end
 end

--- a/spiders/top8_spider.rb
+++ b/spiders/top8_spider.rb
@@ -24,29 +24,12 @@ class Top8Spider < EcommerceEngines::Bsale::Spider
   ]
   @config = {}
 
-  def parse_index(response, url:, data: {})
-    super(response, url:, selector: "div.bs-collection section.grid__item")
-  end
-
-  def next_page_url(response, url)
-    super(response, url, "ul.pagination li:last-child a")
-  end
-
-  private
-
-  def get_title(node)
-    node.at_css("a")[:title]
-  end
-
-  def get_price(node)
-    super(node, "div.bs-collection__product-final-price")
-  end
-
-  def in_stock?(node)
-    super(node, "div.bs-collection__stock")
-  end
-
-  def get_image_url(node)
-    super(node, "src")
-  end
+  selector :index_product, "div.bs-collection section.grid__item"
+  selector :next_page, "ul.pagination li:last-child a"
+  selector :title,  "h3.bs-collection__product-title"
+  selector :stock,  "div.bs-collection__stock"
+  selector :price,  "div.bs-collection__product-final-price"
+  selector :url, "a"
+  selector :image_tag, "img"
+  selector :image_attr, "src"
 end

--- a/spiders/top8_spider.rb
+++ b/spiders/top8_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Top8 store spider
-# Engine: bsale.cl
-class Top8Spider < ApplicationSpider
+class Top8Spider < EcommerceEngines::Bsale::Spider
   @name = "top8_spider"
   @store = {
     name: "Top8",
@@ -25,72 +24,29 @@ class Top8Spider < ApplicationSpider
   ]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
   def parse_index(response, url:, data: {})
-    listings = response.css("div.bs-collection section.grid__item")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node, url),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
+    super(response, url:, selector: "div.bs-collection section.grid__item")
   end
 
   def next_page_url(response, url)
-    next_page_node = response.at_css("ul.pagination li:last-child a")
-    return unless next_page_node
-
-    absolute_url(next_page_node[:href], base: url)
+    super(response, url, "ul.pagination li:last-child a")
   end
 
   private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node, url)
-    rel_url = node.at_css("a")[:href]
-    absolute_url(rel_url, base: url)
-  end
 
   def get_title(node)
     node.at_css("a")[:title]
   end
 
   def get_price(node)
-    price_node = node.at_css("div.bs-collection__product-final-price")
-    scan_int(price_node.text)
+    super(node, "div.bs-collection__product-final-price")
   end
 
   def in_stock?(node)
-    # only present in out-of-stock items
-    node.at_css("div.bs-collection__stock").nil?
-  end
-
-  def purchasable?(node)
-    in_stock?(node)
+    super(node, "div.bs-collection__stock")
   end
 
   def get_image_url(node)
-    node.at_css("img")["src"].then do |url|
-      uri = URI.parse(url)
-      uri.query = nil
-      uri.to_s
-    end
-  rescue NoMethodError
-    nil
+    super(node, "src")
   end
 end

--- a/spiders/topo_token_spider.rb
+++ b/spiders/topo_token_spider.rb
@@ -20,15 +20,5 @@ class TopoTokenSpider < EcommerceEngines::WooCommerce::Spider
     in_stock?(node) && !protected?(node)
   end
 
-  def get_image_url(node)
-    # matches an url like: "https://topotoken.cl/wp-content/uploads/2024/11/BOTCT-Box-3D-2-300x300.png"
-    regex = /(?<url>.*)(?<size>-\d+x\d+)(?<ext>\..*)/
-
-    full_url = node.at_css("img")["src"]
-    match = full_url.match(regex)
-
-    "#{match[:url]}#{match[:ext]}"
-  rescue NoMethodError
-    nil
-  end
+  image_url_strategy(:sized)
 end

--- a/spiders/topo_token_spider.rb
+++ b/spiders/topo_token_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Topo Token store spider
-# Engine: woocommerce
-class TopoTokenSpider < ApplicationSpider
+class TopoTokenSpider < EcommerceEngines::WooCommerce::Spider
   @name = "topo_token_spider"
   @store = {
     name: "Topo Token",
@@ -11,58 +10,7 @@ class TopoTokenSpider < ApplicationSpider
   @start_urls = ["https://topotoken.cl/tienda"]
   @config = {}
 
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("ul.products li.product")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("nav.woocommerce-pagination li a.next")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
-
   private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node)
-    node.at_css("a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css("h2").text.strip
-  end
-
-  def get_price(node)
-    price_node = node.css("span.price bdi").last
-    scan_int(price_node.text) if price_node
-  end
-
-  def in_stock?(_node)
-    true
-  end
 
   def protected?(node)
     node.classes.include?("post-password-required")

--- a/spiders/updown_spider.rb
+++ b/spiders/updown_spider.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Updown store spider
-# Engine: woocommerce
-class UpdownSpider < ApplicationSpider
+class UpdownSpider < EcommerceEngines::WooCommerce::Spider
   @name = "updown_spider"
   @store = {
     name: "Updown",
@@ -10,63 +9,4 @@ class UpdownSpider < ApplicationSpider
   }
   @start_urls = ["https://www.updown.cl/categoria-producto/juegos-de-mesa/"]
   @config = {}
-
-  def parse(response, url:, data: {})
-    items = parse_index(response, url:)
-    items.each { |item| send_item item }
-
-    paginate(response, url)
-  end
-
-  def parse_index(response, url:, data: {})
-    listings = response.css("ul.products li.product")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def parse_product_node(node, url:)
-    {
-      url: get_url(node),
-      title: get_title(node),
-      price: get_price(node),
-      stock: purchasable?(node),
-      image_url: get_image_url(node)
-    }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("nav.woocommerce-pagination li a.next")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
-
-  private
-
-  def paginate(response, url)
-    next_page_url = next_page_url(response, url)
-    request_to(:parse, url: next_page_url) if next_page_url
-  end
-
-  def get_url(node)
-    node.at_css("a")[:href]
-  end
-
-  def get_title(node)
-    node.at_css("h2").text
-  end
-
-  def get_price(node)
-    price_node = node.css("span.price bdi").last
-    scan_int(price_node.text)
-  end
-
-  def purchasable?(_node)
-    true
-  end
-
-  def get_image_url(node)
-    node.at_css("img")["srcset"].split(", ").last.split.first
-  rescue NoMethodError
-    nil
-  end
 end

--- a/spiders/updown_spider.rb
+++ b/spiders/updown_spider.rb
@@ -9,4 +9,6 @@ class UpdownSpider < EcommerceEngines::WooCommerce::Spider
   }
   @start_urls = ["https://www.updown.cl/categoria-producto/juegos-de-mesa/"]
   @config = {}
+
+  image_url_strategy(:srcset)
 end

--- a/spiders/vudugaming_spider.rb
+++ b/spiders/vudugaming_spider.rb
@@ -16,10 +16,5 @@ class VudugamingSpider < EcommerceEngines::Jumpseller::Spider
   selector :title, "h2"
   selector  :price, "div.product-block__price"
   selector  :stock, "div.product-block__actions a[title]"
-
-  private
-
-  def get_image_url(node)
-    super(node, "resize")
-  end
+  selector :image_split, "resize"
 end

--- a/spiders/vudugaming_spider.rb
+++ b/spiders/vudugaming_spider.rb
@@ -10,32 +10,14 @@ class VudugamingSpider < EcommerceEngines::Jumpseller::Spider
   @start_urls = ["https://www.vudugaming.cl/juegos-de-mesa"]
   @config = {}
 
-  def parse_index(response, url:, data: {})
-    listings = response.css("article.product-block")
-    listings.map { |listing| parse_product_node(listing, url:) }
-  end
-
-  def next_page_url(response, url)
-    next_page = response.at_css("ul.pager li.next a")
-    return unless next_page
-
-    absolute_url(next_page[:href], base: url)
-  end
+  selector :index_product, "article.product-block"
+  selector :next_page, "ul.pager li.next a"
+  selector :url, "a"
+  selector :title, "h2"
+  selector  :price, "div.product-block__price"
+  selector  :stock, "div.product-block__actions a[title]"
 
   private
-
-  def get_title(node)
-    node.at_css("h2").text.strip
-  end
-
-  def get_price(node)
-    price_node = node.at_css("div.product-block__price")
-    scan_int(price_node.text)
-  end
-
-  def in_stock?(node)
-    !node.at_css(".product-block__actions form").nil?
-  end
 
   def get_image_url(node)
     super(node, "resize")


### PR DESCRIPTION
Most of the spider code had duplicated logic across both ecommerce engines and individual spiders.

This PR introduces three main changes:
- Extract shared spider logic (#parse, #parse_index, #paginate, #get_*, etc.) into `ApplicationSpider`
- Move Ecommerce engine specific logic into `Ecommerce::Vendor::Spider` subclasses
- Add a small DSL for defining CSS selectors via the `ApplicationSpider.selector` method

The result is a significant reduction in duplication and the removal of about 1,400 lines of code across all store spiders. This puts us in a much better position to continue expanding the spider collection in a more sustainable and maintainable way.