### PR TITLE
Fix/issue 3 url tracking params

### DIFF
--- a/pipelines/formatter.rb
+++ b/pipelines/formatter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-class TitleFormatter < Tanakai::Pipeline
+# Formats an item attributes
+class Formatter < Tanakai::Pipeline
   def process_item(item, options: {})
     item[:title] = format_title(item[:title])
 

--- a/pipelines/formatter.rb
+++ b/pipelines/formatter.rb
@@ -5,6 +5,7 @@ class Formatter < Tanakai::Pipeline
   def process_item(item, options: {})
     item[:title] = format_title(item[:title])
     item[:url] = format_url(item[:url])
+    item[:image_url] = format_url(item[:image_url])
 
     item
   end

--- a/pipelines/formatter.rb
+++ b/pipelines/formatter.rb
@@ -4,6 +4,7 @@
 class Formatter < Tanakai::Pipeline
   def process_item(item, options: {})
     item[:title] = format_title(item[:title])
+    item[:url] = format_url(item[:url])
 
     item
   end
@@ -12,5 +13,16 @@ class Formatter < Tanakai::Pipeline
 
   def format_title(title)
     title.strip
+  end
+
+  def strip_url(url)
+    uri = URI.parse(url)
+    uri.query = nil
+    uri.fragment = nil
+    uri.to_s
+  end
+
+  def format_url(url)
+    strip_url(url)
   end
 end

--- a/pipelines/formatter.rb
+++ b/pipelines/formatter.rb
@@ -5,7 +5,7 @@ class Formatter < Tanakai::Pipeline
   def process_item(item, options: {})
     item[:title] = format_title(item[:title])
     item[:url] = format_url(item[:url])
-    item[:image_url] = format_url(item[:image_url])
+    item[:image_url] = format_image_url(item[:image_url])
 
     item
   end
@@ -25,5 +25,9 @@ class Formatter < Tanakai::Pipeline
 
   def format_url(url)
     strip_url(url)
+  end
+
+  def format_image_url(url)
+    format_url(url)
   end
 end

--- a/pipelines/title_formatter.rb
+++ b/pipelines/title_formatter.rb
@@ -2,17 +2,14 @@
 
 class TitleFormatter < Tanakai::Pipeline
   def process_item(item, options: {})
-    # remove whitespace
-    item[:title].strip!
-
-    # remove trailing language
-    # (disabled because storing the original ingo as-is might be more valuable)
-    #
-    # languages = %w[Inglés Español].flat_map { [it, it.downcase] }
-    # formats = [" - %s", " (%s)"]
-    # suffixes = languages.product(formats).map { |lang, fmt| format(fmt, lang) }
-    # suffixes.each { |suffix| item[:title].delete_suffix!(suffix) }
+    item[:title] = format_title(item[:title])
 
     item
+  end
+
+  private
+
+  def format_title(title)
+    title.strip
   end
 end

--- a/spec/pipeline_helper.rb
+++ b/spec/pipeline_helper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "tanakai_helper"
+
+RSpec.shared_examples "a URL sanitizer" do |field|
+  subject(:formatted_item) { pipeline.process_item(item) }
+
+  context "when #{field} has query parameters" do
+    let(field) { "https://example.com/path?foo=bar&baz=qux" }
+
+    it "removes query parameters" do
+      expect(formatted_item[field]).to eq("https://example.com/path")
+    end
+  end
+
+  context "when #{field} has a fragment" do
+    let(field) { "https://example.com/path#section" }
+
+    it "removes fragment" do
+      expect(formatted_item[field]).to eq("https://example.com/path")
+    end
+  end
+
+  context "when #{field} has both query parameters and a fragment" do
+    let(field) { "https://example.com/path?foo=bar#section" }
+
+    it "removes both" do
+      expect(formatted_item[field]).to eq("https://example.com/path")
+    end
+  end
+end

--- a/spec/pipelines/formatter_spec.rb
+++ b/spec/pipelines/formatter_spec.rb
@@ -30,4 +30,16 @@ RSpec.describe Formatter do
     formated_item = pipeline.process_item(item)
     expect(formated_item[:url]).to eq("https://lateka.cl/products/7-wonders-edifice-expansion")
   end
+
+  it "removes url fragment" do
+    item[:url] = "https://lateka.cl/products/7-wonders-edifice-expansion#example"
+    formated_item = pipeline.process_item(item)
+    expect(formated_item[:url]).to eq("https://lateka.cl/products/7-wonders-edifice-expansion")
+  end
+
+  it "removes url query parameters and fragments" do
+    item[:url] = "https://lateka.cl/products/7-wonders-edifice-expansion?_pos=232&_fid=c752bb366&_ss=c#example"
+    formated_item = pipeline.process_item(item)
+    expect(formated_item[:url]).to eq("https://lateka.cl/products/7-wonders-edifice-expansion")
+  end
 end

--- a/spec/pipelines/formatter_spec.rb
+++ b/spec/pipelines/formatter_spec.rb
@@ -45,5 +45,11 @@ RSpec.describe Formatter do
       formated_item = pipeline.process_item(item)
       expect(formated_item[:url]).to eq("https://lateka.cl/products/7-wonders-edifice-expansion")
     end
+
+    it "removes image_url query parameters and fragments" do
+      item[:image_url] = "https://www.flexogames.cl/cdn/shop/files/tabriz_2048x.png?v=1749599354#example"
+      formated_item = pipeline.process_item(item)
+      expect(formated_item[:image_url]).to eq("https://www.flexogames.cl/cdn/shop/files/tabriz_2048x.png")
+    end
   end
 end

--- a/spec/pipelines/formatter_spec.rb
+++ b/spec/pipelines/formatter_spec.rb
@@ -2,7 +2,7 @@
 
 require "tanakai_helper"
 
-RSpec.describe TitleFormatter do
+RSpec.describe Formatter do
   let(:pipeline) do
     instance = described_class.new
     instance.spider = Tanakai::Base.new
@@ -23,5 +23,11 @@ RSpec.describe TitleFormatter do
     item[:title] = " Example Item \n"
     formated_item = pipeline.process_item(item)
     expect(formated_item[:title]).to eq("Example Item")
+  end
+
+  it "removes url query parameters" do
+    item[:url] = "https://lateka.cl/products/7-wonders-edifice-expansion?_pos=232&_fid=c752bb366&_ss=c"
+    formated_item = pipeline.process_item(item)
+    expect(formated_item[:url]).to eq("https://lateka.cl/products/7-wonders-edifice-expansion")
   end
 end

--- a/spec/pipelines/formatter_spec.rb
+++ b/spec/pipelines/formatter_spec.rb
@@ -19,27 +19,31 @@ RSpec.describe Formatter do
     }
   end
 
-  it "formats the item title" do
-    item[:title] = " Example Item \n"
-    formated_item = pipeline.process_item(item)
-    expect(formated_item[:title]).to eq("Example Item")
+  describe "#format_title" do
+    it "formats the item title" do
+      item[:title] = " Example Item \n"
+      formated_item = pipeline.process_item(item)
+      expect(formated_item[:title]).to eq("Example Item")
+    end
   end
 
-  it "removes url query parameters" do
-    item[:url] = "https://lateka.cl/products/7-wonders-edifice-expansion?_pos=232&_fid=c752bb366&_ss=c"
-    formated_item = pipeline.process_item(item)
-    expect(formated_item[:url]).to eq("https://lateka.cl/products/7-wonders-edifice-expansion")
-  end
+  describe "#format_url" do
+    it "removes url query parameters" do
+      item[:url] = "https://lateka.cl/products/7-wonders-edifice-expansion?_pos=232&_fid=c752bb366&_ss=c"
+      formated_item = pipeline.process_item(item)
+      expect(formated_item[:url]).to eq("https://lateka.cl/products/7-wonders-edifice-expansion")
+    end
 
-  it "removes url fragment" do
-    item[:url] = "https://lateka.cl/products/7-wonders-edifice-expansion#example"
-    formated_item = pipeline.process_item(item)
-    expect(formated_item[:url]).to eq("https://lateka.cl/products/7-wonders-edifice-expansion")
-  end
+    it "removes url fragment" do
+      item[:url] = "https://lateka.cl/products/7-wonders-edifice-expansion#example"
+      formated_item = pipeline.process_item(item)
+      expect(formated_item[:url]).to eq("https://lateka.cl/products/7-wonders-edifice-expansion")
+    end
 
-  it "removes url query parameters and fragments" do
-    item[:url] = "https://lateka.cl/products/7-wonders-edifice-expansion?_pos=232&_fid=c752bb366&_ss=c#example"
-    formated_item = pipeline.process_item(item)
-    expect(formated_item[:url]).to eq("https://lateka.cl/products/7-wonders-edifice-expansion")
+    it "removes url query parameters and fragments" do
+      item[:url] = "https://lateka.cl/products/7-wonders-edifice-expansion?_pos=232&_fid=c752bb366&_ss=c#example"
+      formated_item = pipeline.process_item(item)
+      expect(formated_item[:url]).to eq("https://lateka.cl/products/7-wonders-edifice-expansion")
+    end
   end
 end

--- a/spec/pipelines/title_formatter_spec.rb
+++ b/spec/pipelines/title_formatter_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "tanakai_helper"
+
+RSpec.describe TitleFormatter do
+  let(:pipeline) do
+    instance = described_class.new
+    instance.spider = Tanakai::Base.new
+    instance
+  end
+
+  let(:item) do
+    {
+      url: "https://www.example.com/item/1",
+      title: "Example Item",
+      price: 123_456,
+      stock: true,
+      image_url: "https://www.example.com/item/1.jpg"
+    }
+  end
+
+  it "formats the item title" do
+    item[:title] = " Example Item \n"
+    formated_item = pipeline.process_item(item)
+    expect(formated_item[:title]).to eq("Example Item")
+  end
+end

--- a/spiders/application_spider.rb
+++ b/spiders/application_spider.rb
@@ -12,7 +12,7 @@ class ApplicationSpider < Tanakai::Base
 
   # Pipelines list, by order.
   # To process item through pipelines pass item to the `send_item` method
-  @pipelines = %i[title_formatter validator saver]
+  @pipelines = %i[formatter validator saver]
 
   # Default config. Set here options which are default for all spiders inherited
   # from ApplicationSpider. Child's class config will be deep merged with this one

--- a/spiders/la_teka_spider.rb
+++ b/spiders/la_teka_spider.rb
@@ -7,7 +7,7 @@ class LaTekaSpider < EcommerceEngines::Shopify::Spider
     name: "La Teka",
     url: "https://lateka.cl"
   }
-  @start_urls = ["https://lateka.cl/collections/juegos-de-mesa?filter.v.availability=1"]
+  @start_urls = ["https://lateka.cl/collections/juegos-de-mesa"]
   @config = {}
 
   selector :index_product, "ul#product-grid div.card"


### PR DESCRIPTION
Fixes #3

A revision of the `lateka.cl` store website showed that adding the url parameter `filter.v.availability=1` makes the store to generate links with a tracking ID.

To solve this issue and prevent regressions, this PR introduces the following changes:
- Remove the problematic availability filter from the spider start_url
- Add a new `Formatter` pipeline class
- Add relevant `Formatter` unit tests to prevent regressions